### PR TITLE
Agent build pr48 fixes

### DIFF
--- a/app/src/main/java/com/xzyht/notifyrelay/feature/device/service/DeviceConnectionManager.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/feature/device/service/DeviceConnectionManager.kt
@@ -612,7 +612,13 @@ class DeviceConnectionManager(private val context: android.content.Context) {
                 addAction(Intent.ACTION_SCREEN_ON)
                 addAction(Intent.ACTION_USER_PRESENT)
             }
-            context.registerReceiver(lockStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            // 问题 1 修复：RECEIVER_NOT_EXPORTED 语义仅 API 33+ 生效，API 31/32 上等效 exported。
+            // 三参数重载 API 26+ 已存在，但显式分支可避免在低版本上误传未定义 flag。
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(lockStateReceiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                context.registerReceiver(lockStateReceiver, filter)
+            }
         } catch (_: Exception) {}
     }
 
@@ -641,11 +647,19 @@ class DeviceConnectionManager(private val context: android.content.Context) {
             }
         }
         try {
-            context.registerReceiver(
-                batteryReceiver,
-                IntentFilter(Intent.ACTION_BATTERY_CHANGED),
-                Context.RECEIVER_NOT_EXPORTED
-            )
+            // 问题 1 修复：同上，RECEIVER_NOT_EXPORTED 仅 API 33+ 生效。
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.registerReceiver(
+                    batteryReceiver,
+                    IntentFilter(Intent.ACTION_BATTERY_CHANGED),
+                    Context.RECEIVER_NOT_EXPORTED
+                )
+            } else {
+                context.registerReceiver(
+                    batteryReceiver,
+                    IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+                )
+            }
         } catch (_: Exception) {}
     }
 

--- a/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendLocalFilter.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendLocalFilter.kt
@@ -13,6 +13,10 @@ import kotlinx.coroutines.runBlocking
 /**
  * 后端本机通知过滤器
  * 处理本机产生的通知的过滤逻辑
+ *
+ * 注：本类中所有数据访问方法均为 suspend。`shouldForwardBlocking` 保留 runBlocking
+ * 兜底用于通知监听服务的同步回调（NotificationListenerService.onNotificationPosted），
+ * 其余调用方（UI/ViewModel）应使用 suspend 版本。
  */
 object BackendLocalFilter {
     // 可配置项
@@ -51,17 +55,19 @@ object BackendLocalFilter {
     // FilterEntry 表示一条复合过滤规则：keyword 可空，packageName 可空
     data class FilterEntry(val keyword: String, val packageName: String)
 
-    // 获取所有过滤条目（包含内置关键词和默认包名过滤），表为空时初始化内置条目
-    fun getFilterEntries(context: Context): Set<FilterEntry> {
-        val rows = runBlocking { DatabaseRepository.getInstance(context).getLocalFilterEntries() }
+    /**
+     * 获取所有过滤条目（包含内置关键词和默认包名过滤），表为空时初始化内置条目。
+     * 单次查询：仅在结果为空时写入内置条目并返回，避免每次调用产生 2 次查询。
+     */
+    suspend fun getFilterEntries(context: Context): Set<FilterEntry> {
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries()
         if (rows.isEmpty()) {
-            // 初始化：写入内置条目
+            // 初始化：写入内置条目（默认启用）
             val entries = builtinFilterEntries
-            runBlocking {
-                DatabaseRepository.getInstance(context).replaceLocalFilterEntries(
-                    entries.map { FilterEntryEntity(it.keyword, it.packageName, true) }
-                )
-            }
+            repo.replaceLocalFilterEntries(
+                entries.map { FilterEntryEntity(it.keyword, it.packageName, true) }
+            )
             return entries
         }
         return rows.map { FilterEntry(it.keyword, it.packageName) }.toSet()
@@ -70,97 +76,110 @@ object BackendLocalFilter {
     // 获取内置默认关键词集合（兼容旧接口）
     fun getBuiltinKeywords(): Set<String> = builtinFilterEntries.filter { it.keyword.isNotBlank() }.map { it.keyword }.toSet()
 
-    // 获取启用的过滤条目集合（内置条目恒启用）
-    fun getEnabledFilterEntries(context: Context): Set<FilterEntry> {
-        val all = getFilterEntries(context)
-        val rows = runBlocking { DatabaseRepository.getInstance(context).getLocalFilterEntries() }
-        val result = rows.filter { it.enabled }.map { FilterEntry(it.keyword, it.packageName) }.toMutableSet()
-        builtinFilterEntries.forEach { entry ->
-            if (all.contains(entry)) result.add(entry)
+    /**
+     * 获取启用的过滤条目集合。
+     * 单次查询：基于同一份 rows 派生启用集合，不再强制加回内置条目（允许用户禁用内置条目）。
+     */
+    suspend fun getEnabledFilterEntries(context: Context): Set<FilterEntry> {
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries()
+        if (rows.isEmpty()) {
+            // 表为空时初始化内置条目并返回全部启用
+            val entries = builtinFilterEntries
+            repo.replaceLocalFilterEntries(
+                entries.map { FilterEntryEntity(it.keyword, it.packageName, true) }
+            )
+            return entries
         }
-        return result
+        return rows.filter { it.enabled }.map { FilterEntry(it.keyword, it.packageName) }.toSet()
     }
 
-    fun setFilterEntryEnabled(context: Context, entry: FilterEntry, enabled: Boolean) {
-        runBlocking {
-            val repo = DatabaseRepository.getInstance(context)
-            val rows = repo.getLocalFilterEntries().toMutableList()
-            val idx = rows.indexOfFirst { it.keyword == entry.keyword && it.packageName == entry.packageName }
-            if (idx >= 0) {
-                rows[idx] = rows[idx].copy(enabled = enabled)
-            } else {
-                rows.add(FilterEntryEntity(entry.keyword, entry.packageName, enabled))
-            }
+    suspend fun setFilterEntryEnabled(context: Context, entry: FilterEntry, enabled: Boolean) {
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries().toMutableList()
+        val idx = rows.indexOfFirst { it.keyword == entry.keyword && it.packageName == entry.packageName }
+        if (idx >= 0) {
+            rows[idx] = rows[idx].copy(enabled = enabled)
+        } else {
+            rows.add(FilterEntryEntity(entry.keyword, entry.packageName, enabled))
+        }
+        repo.replaceLocalFilterEntries(rows)
+    }
+
+    suspend fun addFilterEntry(context: Context, keyword: String, packageName: String) {
+        val entry = FilterEntry(keyword.trim(), packageName.trim())
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries().toMutableList()
+        if (rows.none { it.keyword == entry.keyword && it.packageName == entry.packageName }) {
+            rows.add(FilterEntryEntity(entry.keyword, entry.packageName, true))
             repo.replaceLocalFilterEntries(rows)
         }
     }
 
-    fun addFilterEntry(context: Context, keyword: String, packageName: String) {
-        val entry = FilterEntry(keyword.trim(), packageName.trim())
-        runBlocking {
-            val repo = DatabaseRepository.getInstance(context)
-            val rows = repo.getLocalFilterEntries().toMutableList()
-            if (rows.none { it.keyword == entry.keyword && it.packageName == entry.packageName }) {
-                rows.add(FilterEntryEntity(entry.keyword, entry.packageName, true))
-                repo.replaceLocalFilterEntries(rows)
-            }
-        }
-    }
-
-    fun removeFilterEntry(context: Context, keyword: String, packageName: String) {
+    suspend fun removeFilterEntry(context: Context, keyword: String, packageName: String) {
         // 内置条目不可删除（包括内置文本关键词和默认包名）
         if ((packageName.isBlank() && builtinFilterEntries.any { it.keyword == keyword && it.keyword.isNotBlank() }) || (keyword.isBlank() && builtinFilterEntries.any { it.packageName == packageName && it.packageName.isNotBlank() })) return
-        runBlocking {
-            val repo = DatabaseRepository.getInstance(context)
-            val rows = repo.getLocalFilterEntries().filterNot { it.keyword == keyword && it.packageName == packageName }
-            repo.replaceLocalFilterEntries(rows)
-        }
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries().filterNot { it.keyword == keyword && it.packageName == packageName }
+        repo.replaceLocalFilterEntries(rows)
     }
 
     // 兼容的旧 API：返回仅 keyword（package 为空）的集合
-    fun getForegroundKeywords(context: Context): Set<String> {
+    suspend fun getForegroundKeywords(context: Context): Set<String> {
         return getFilterEntries(context).filter { it.packageName.isBlank() }.map { it.keyword }.toSet()
     }
 
     // 兼容的旧 API：返回仅 package 的集合（包含默认）
-    fun getPackageFilterList(context: Context): Set<String> {
+    suspend fun getPackageFilterList(context: Context): Set<String> {
         val pkgs = getFilterEntries(context).filter { it.keyword.isBlank() && it.packageName.isNotBlank() }.map { it.packageName }.toMutableSet()
         // 添加内置默认包名
         pkgs.addAll(builtinFilterEntries.filter { it.packageName.isNotBlank() }.map { it.packageName })
         return pkgs
     }
 
-    fun addPackageFilter(context: Context, packageName: String) {
+    suspend fun addPackageFilter(context: Context, packageName: String) {
         if (packageName.isBlank()) return
         addFilterEntry(context, "", packageName)
     }
 
-    fun removePackageFilter(context: Context, packageName: String) {
+    suspend fun removePackageFilter(context: Context, packageName: String) {
         // 默认包名不可删除
         if (builtinFilterEntries.any { it.packageName == packageName && it.packageName.isNotBlank() }) return
         removeFilterEntry(context, "", packageName)
     }
 
-    fun getEnabledPackageFilters(context: Context): Set<String> {
+    suspend fun getEnabledPackageFilters(context: Context): Set<String> {
         return getEnabledFilterEntries(context).filter { it.keyword.isBlank() && it.packageName.isNotBlank() }.map { it.packageName }.toSet()
     }
 
     // 获取默认包名过滤集合（从内置条目提取）
     fun getDefaultPackageFilters(): Set<String> = builtinFilterEntries.filter { it.packageName.isNotBlank() }.map { it.packageName }.toSet()
 
-    fun setPackageEnabled(context: Context, packageName: String, enabled: Boolean) {
+    suspend fun setPackageEnabled(context: Context, packageName: String, enabled: Boolean) {
         setFilterEntryEnabled(context, FilterEntry("", packageName), enabled)
     }
 
     /**
-     * 判断本机通知是否应该被转发
+     * 判断本机通知是否应该被转发（suspend 版本，热路径仅一次查询）。
      * @param isFromPeriodicCheck 是否来自定时检查，避免调试日志刷屏
      */
-    fun shouldForward(sbn: StatusBarNotification, context: Context, isFromPeriodicCheck: Boolean = false): Boolean {
+    suspend fun shouldForward(sbn: StatusBarNotification, context: Context, isFromPeriodicCheck: Boolean = false): Boolean {
         if (filterSelf && sbn.packageName == context.packageName) return false
 
-        // 包名过滤
-        val enabledPackageFilters = getEnabledPackageFilters(context)
+        // 单次查询：基于同一份 rows 派生 enabled 与 all，避免热路径上重复查询
+        val repo = DatabaseRepository.getInstance(context)
+        val rows = repo.getLocalFilterEntries()
+        // 表为空时初始化内置条目（与 getFilterEntries 一致）
+        if (rows.isEmpty()) {
+            repo.replaceLocalFilterEntries(
+                builtinFilterEntries.map { FilterEntryEntity(it.keyword, it.packageName, true) }
+            )
+        }
+
+        // 包名过滤：仅使用 enabled 集合
+        val enabledEntries = if (rows.isEmpty()) builtinFilterEntries
+        else rows.filter { it.enabled }.map { FilterEntry(it.keyword, it.packageName) }.toSet()
+        val enabledPackageFilters = enabledEntries.filter { it.keyword.isBlank() && it.packageName.isNotBlank() }.map { it.packageName }.toSet()
         if (enabledPackageFilters.contains(sbn.packageName)) return false
 
         val flags = sbn.notification.flags
@@ -181,7 +200,6 @@ object BackendLocalFilter {
         // - entry.keyword 非空 且 packageName 为空 -> 只匹配文本（任意应用）
         // - entry.keyword 为空 且 packageName 非空 -> 只匹配包名
         // - 两者均非空 -> 同时匹配才命中
-        val enabledEntries = getEnabledFilterEntries(context)
         // 新的匹配逻辑：支持关键字按空格分词后跨标题/内容匹配。
         // 例如 keyword = "米家 手表" 时，如果 title 包含 "米家" 且 text 包含 "手表" 也应视为命中。
         fun keywordMatchesAcrossFields(keyword: String, title: String, text: String): Boolean {
@@ -231,4 +249,12 @@ object BackendLocalFilter {
 
         return true
     }
+
+    /**
+     * 同步兜底版本：供 NotificationListenerService 的非挂起回调使用。
+     * 内部通过 runBlocking 调用 suspend 版本，保留服务回调语义不变。
+     * 注意：仅在无法改造为协程的同步入口使用，新代码应优先调用 suspend 版本。
+     */
+    fun shouldForwardBlocking(sbn: StatusBarNotification, context: Context, isFromPeriodicCheck: Boolean = false): Boolean =
+        runBlocking { shouldForward(sbn, context, isFromPeriodicCheck) }
 }

--- a/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendRemoteFilter.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendRemoteFilter.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 import org.json.JSONArray
@@ -461,6 +463,14 @@ object RemoteFilterConfig {
     private const val KEY_ENABLE_DEDUP = "enable_dedup"
     private const val KEY_ENABLE_PEER = "enable_peer"
 
+    /**
+     * 保存串行化互斥锁：多个 UI 回调通过 scope.launch { save() } 并发触发时，
+     * 用 Mutex.withLock 让保存排队执行，避免后触发者先完成、先触发者后完成
+     * 覆盖回旧状态的竞态。注意必须用同一把跨实例锁（object 单例），
+     * 因此声明在 object 顶层而非 save() 局部。
+     */
+    private val saveLock = Mutex()
+
     // 标记配置是否已加载，避免重复加载
     var isLoaded: Boolean = false
 
@@ -553,24 +563,28 @@ object RemoteFilterConfig {
 
     // 保存设置（优化性能）
     suspend fun save(context: Context) {
-        withContext(Dispatchers.IO) {
-            try {
-                StorageManager.putBoolean(context, "enable_package_group_mapping", enablePackageGroupMapping, StorageManager.PrefsType.FILTER)
-                StorageManager.putString(context, KEY_FILTER_MODE, filterMode, StorageManager.PrefsType.FILTER)
-                StorageManager.putBoolean(context, KEY_ENABLE_DEDUP, enableDeduplication, StorageManager.PrefsType.FILTER)
-                StorageManager.putBoolean(context, KEY_ENABLE_PEER, enablePeerMode, StorageManager.PrefsType.FILTER)
-                StorageManager.putBoolean(context, "enable_lock_screen_only", enableLockScreenOnly, StorageManager.PrefsType.FILTER)
-                saveFilterLists(context)
-                savePackageGroups(context)
+        // 并发串行化：UI 回调通过 scope.launch 并发触发 save 时，用 Mutex 排队，
+        // 保证保存按触发顺序完成，最终持久化结果与最新 UI 状态一致。
+        saveLock.withLock {
+            withContext(Dispatchers.IO) {
+                try {
+                    StorageManager.putBoolean(context, "enable_package_group_mapping", enablePackageGroupMapping, StorageManager.PrefsType.FILTER)
+                    StorageManager.putString(context, KEY_FILTER_MODE, filterMode, StorageManager.PrefsType.FILTER)
+                    StorageManager.putBoolean(context, KEY_ENABLE_DEDUP, enableDeduplication, StorageManager.PrefsType.FILTER)
+                    StorageManager.putBoolean(context, KEY_ENABLE_PEER, enablePeerMode, StorageManager.PrefsType.FILTER)
+                    StorageManager.putBoolean(context, "enable_lock_screen_only", enableLockScreenOnly, StorageManager.PrefsType.FILTER)
+                    saveFilterLists(context)
+                    savePackageGroups(context)
 
-                // 保存后立即同步到 Rust 侧
-                val ctx = BackendRemoteFilter.rustContext
-                if (ctx != null) {
-                    val installedPkgs = AppRepository.getInstalledPackageNamesSync(context)
-                    syncToRust(ctx, installedPkgs)
+                    // 保存后立即同步到 Rust 侧
+                    val ctx = BackendRemoteFilter.rustContext
+                    if (ctx != null) {
+                        val installedPkgs = AppRepository.getInstalledPackageNamesSync(context)
+                        syncToRust(ctx, installedPkgs)
+                    }
+                } catch (e: Exception) {
+                    Logger.e("RemoteFilterConfig", "Failed to save configuration", e)
                 }
-            } catch (e: Exception) {
-                Logger.e("RemoteFilterConfig", "Failed to save configuration", e)
             }
         }
     }

--- a/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendRemoteFilter.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendRemoteFilter.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 import org.json.JSONArray
 import org.json.JSONObject
@@ -71,13 +73,16 @@ object BackendRemoteFilter {
     /**
      * 过滤远程通知
      * 包含包名映射（Rust）、智能去重、黑白名单/对等模式（Rust）
+     *
+     * 同步契约：被消息处理链（NotificationProcessor.process，非 suspend）调用，
+     * 无法直接挂起。配置加载通过 loadBlocking 兜底（仅首次加载，后续 isLoaded 短路）。
      */
     fun filterRemoteNotification(data: String, context: Context): FilterResult {
         // 确保配置已加载（只加载一次）
         synchronized(RemoteFilterConfig) {
             if (!RemoteFilterConfig.isLoaded) {
                 try {
-                    RemoteFilterConfig.load(context)
+                    RemoteFilterConfig.loadBlocking(context)
                     RemoteFilterConfig.isLoaded = true
                     rustContext?.let { ctx ->
                         val installedPkgs = AppRepository.getInstalledPackageNamesSync(context)
@@ -499,19 +504,24 @@ object RemoteFilterConfig {
     var enableLockScreenOnly: Boolean = true
 
     // 加载设置
-    fun load(context: Context) {
-        enablePackageGroupMapping = StorageManager.getBoolean(context, "enable_package_group_mapping", true, StorageManager.PrefsType.FILTER)
-        filterMode = StorageManager.getString(context, KEY_FILTER_MODE, "none", StorageManager.PrefsType.FILTER)
-        enableDeduplication = StorageManager.getBoolean(context, KEY_ENABLE_DEDUP, true, StorageManager.PrefsType.FILTER)
-        enablePeerMode = StorageManager.getBoolean(context, KEY_ENABLE_PEER, false, StorageManager.PrefsType.FILTER)
-        enableLockScreenOnly = StorageManager.getBoolean(context, "enable_lock_screen_only", true, StorageManager.PrefsType.FILTER)
-        loadFilterLists(context)
-        loadPackageGroups(context)
-        isLoaded = true
+    suspend fun load(context: Context) {
+        withContext(Dispatchers.IO) {
+            enablePackageGroupMapping = StorageManager.getBoolean(context, "enable_package_group_mapping", true, StorageManager.PrefsType.FILTER)
+            filterMode = StorageManager.getString(context, KEY_FILTER_MODE, "none", StorageManager.PrefsType.FILTER)
+            enableDeduplication = StorageManager.getBoolean(context, KEY_ENABLE_DEDUP, true, StorageManager.PrefsType.FILTER)
+            enablePeerMode = StorageManager.getBoolean(context, KEY_ENABLE_PEER, false, StorageManager.PrefsType.FILTER)
+            enableLockScreenOnly = StorageManager.getBoolean(context, "enable_lock_screen_only", true, StorageManager.PrefsType.FILTER)
+            loadFilterLists(context)
+            loadPackageGroups(context)
+            isLoaded = true
+        }
     }
 
-    private fun loadFilterLists(context: Context) {
-        kotlinx.coroutines.runBlocking {
+    /** 同步兜底：仅供 filterRemoteNotification 等无法挂起的同步入口使用 */
+    fun loadBlocking(context: Context) = runBlocking { load(context) }
+
+    private suspend fun loadFilterLists(context: Context) {
+        withContext(Dispatchers.IO) {
             val repo = notifyrelay.data.database.repository.DatabaseRepository.getInstance(context)
             val blackRows = repo.getBlackList()
             blackList = blackRows.map { it.packageName to it.keyword.takeIf { k -> k.isNotBlank() } }
@@ -524,8 +534,8 @@ object RemoteFilterConfig {
         }
     }
 
-    private fun loadPackageGroups(context: Context) {
-        kotlinx.coroutines.runBlocking {
+    private suspend fun loadPackageGroups(context: Context) {
+        withContext(Dispatchers.IO) {
             val repo = notifyrelay.data.database.repository.DatabaseRepository.getInstance(context)
             val groups = repo.getPackageGroups()
             val items = repo.getPackageGroupItems().groupBy { it.groupId }
@@ -542,29 +552,34 @@ object RemoteFilterConfig {
     }
 
     // 保存设置（优化性能）
-    fun save(context: Context) {
-        try {
-            StorageManager.putBoolean(context, "enable_package_group_mapping", enablePackageGroupMapping, StorageManager.PrefsType.FILTER)
-            StorageManager.putString(context, KEY_FILTER_MODE, filterMode, StorageManager.PrefsType.FILTER)
-            StorageManager.putBoolean(context, KEY_ENABLE_DEDUP, enableDeduplication, StorageManager.PrefsType.FILTER)
-            StorageManager.putBoolean(context, KEY_ENABLE_PEER, enablePeerMode, StorageManager.PrefsType.FILTER)
-            StorageManager.putBoolean(context, "enable_lock_screen_only", enableLockScreenOnly, StorageManager.PrefsType.FILTER)
-            saveFilterLists(context)
-            savePackageGroups(context)
+    suspend fun save(context: Context) {
+        withContext(Dispatchers.IO) {
+            try {
+                StorageManager.putBoolean(context, "enable_package_group_mapping", enablePackageGroupMapping, StorageManager.PrefsType.FILTER)
+                StorageManager.putString(context, KEY_FILTER_MODE, filterMode, StorageManager.PrefsType.FILTER)
+                StorageManager.putBoolean(context, KEY_ENABLE_DEDUP, enableDeduplication, StorageManager.PrefsType.FILTER)
+                StorageManager.putBoolean(context, KEY_ENABLE_PEER, enablePeerMode, StorageManager.PrefsType.FILTER)
+                StorageManager.putBoolean(context, "enable_lock_screen_only", enableLockScreenOnly, StorageManager.PrefsType.FILTER)
+                saveFilterLists(context)
+                savePackageGroups(context)
 
-            // 保存后立即同步到 Rust 侧
-            val ctx = BackendRemoteFilter.rustContext
-            if (ctx != null) {
-                val installedPkgs = AppRepository.getInstalledPackageNamesSync(context)
-                syncToRust(ctx, installedPkgs)
+                // 保存后立即同步到 Rust 侧
+                val ctx = BackendRemoteFilter.rustContext
+                if (ctx != null) {
+                    val installedPkgs = AppRepository.getInstalledPackageNamesSync(context)
+                    syncToRust(ctx, installedPkgs)
+                }
+            } catch (e: Exception) {
+                Logger.e("RemoteFilterConfig", "Failed to save configuration", e)
             }
-        } catch (e: Exception) {
-            Logger.e("RemoteFilterConfig", "Failed to save configuration", e)
         }
     }
 
-    private fun saveFilterLists(context: Context) {
-        kotlinx.coroutines.runBlocking {
+    /** 同步兜底：仅供无法挂起的同步入口使用（如 UI 回调未改协程处） */
+    fun saveBlocking(context: Context) = runBlocking { save(context) }
+
+    private suspend fun saveFilterLists(context: Context) {
+        withContext(Dispatchers.IO) {
             val repo = notifyrelay.data.database.repository.DatabaseRepository.getInstance(context)
             repo.replaceBlackList(blackList.map {
                 notifyrelay.data.database.entity.BlackListEntryEntity(
@@ -583,8 +598,8 @@ object RemoteFilterConfig {
         }
     }
 
-    private fun savePackageGroups(context: Context) {
-        kotlinx.coroutines.runBlocking {
+    private suspend fun savePackageGroups(context: Context) {
+        withContext(Dispatchers.IO) {
             val repo = notifyrelay.data.database.repository.DatabaseRepository.getInstance(context)
             val groups = mutableListOf<notifyrelay.data.database.entity.PackageGroupEntity>()
             val itemPackages = mutableListOf<List<String>>()
@@ -635,7 +650,7 @@ object RemoteFilterConfig {
     }
 
     /** 向当前模式的名单添加条目（默认启用） */
-    fun addFilterEntry(context: Context, pkg: String, keyword: String) {
+    suspend fun addFilterEntry(context: Context, pkg: String, keyword: String) {
         val kw = keyword.takeIf { it.isNotBlank() }
         when (filterMode) {
             "black" -> {
@@ -652,7 +667,7 @@ object RemoteFilterConfig {
     }
 
     /** 从当前模式的名单移除条目 */
-    fun removeFilterEntry(context: Context, pkg: String, keyword: String) {
+    suspend fun removeFilterEntry(context: Context, pkg: String, keyword: String) {
         val ser = serializeFilterEntry(pkg, keyword)
         when (filterMode) {
             "black" -> {
@@ -668,7 +683,7 @@ object RemoteFilterConfig {
     }
 
     /** 启用/禁用当前模式的条目 */
-    fun setFilterEntryEnabled(context: Context, pkg: String, keyword: String, enabled: Boolean) {
+    suspend fun setFilterEntryEnabled(context: Context, pkg: String, keyword: String, enabled: Boolean) {
         val ser = serializeFilterEntry(pkg, keyword)
         when (filterMode) {
             "black" -> blackListEnabled = if (enabled) blackListEnabled + ser else blackListEnabled - ser

--- a/app/src/main/java/com/xzyht/notifyrelay/servers/NotifyRelayNotificationListenerService.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/servers/NotifyRelayNotificationListenerService.kt
@@ -454,7 +454,7 @@ class NotifyRelayNotificationListenerService : NotificationListenerService() {
             return
         }
 
-        if (!BackendLocalFilter.shouldForward(sbn, applicationContext, checkProcessed)) {
+        if (!BackendLocalFilter.shouldForwardBlocking(sbn, applicationContext, checkProcessed)) {
             if (Logger.ENABLE_FILTERED_NOTIFICATION_LOG) {
                 logSbnDetail("法鸡-黑影 被过滤", sbn)
             }

--- a/app/src/main/java/com/xzyht/notifyrelay/sync/ConnectionDiscoveryManager.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/sync/ConnectionDiscoveryManager.kt
@@ -216,6 +216,17 @@ class ConnectionDiscoveryManager(
      *   发现由 known_device_scanner/reconnect 兜底）
      * - 否则 → 广播主用（UDP 广播 2s 兼发现+心跳，Rust 停止每设备心跳）
      */
+
+    /**
+     * 获取带符号电量（正=充电，负=放电），与 BatteryReceiver 约定一致。
+     * Rust 侧：battery > 0 视为充电中，battery < 0 视为放电中。
+     */
+    private fun getSignedBatteryLevel(): Int {
+        val ctx = deviceManager.contextInternal
+        val level = notifyrelay.core.util.BatteryUtils.getBatteryLevel(ctx)
+        return if (notifyrelay.core.util.BatteryUtils.isCharging(ctx)) level else -level
+    }
+
     internal fun syncHeartbeatMode() {
         val ctx = deviceManager.rustContextInternal ?: return
         try {
@@ -225,7 +236,8 @@ class ConnectionDiscoveryManager(
                 NativeCore.periodicBroadcast(ctx, 0)
             } else if (deviceManager.udpDiscoveryEnabled) {
                 val displayName = deviceManager.localDisplayNameInternal()
-                val battery = notifyrelay.core.util.BatteryUtils.getBatteryLevel(deviceManager.contextInternal)
+                // 问题 4 修复：心跳报文电量需带符号（正=充电，负=放电），否则远端会误判全部设备为充电中。
+                val battery = getSignedBatteryLevel()
                 NativeCore.periodicBroadcast(ctx, 1, deviceManager.uuid, displayName, battery, "android")
             }
         } catch (_: Exception) {}
@@ -240,12 +252,13 @@ class ConnectionDiscoveryManager(
 
     fun startDiscovery() {
         val udpEnabled = deviceManager.udpDiscoveryEnabled
-        
+
         // 启动 Rust 定时广播（Wi-Fi Direct 和普通网络都需要）
         val ctx = deviceManager.rustContextInternal
         if (ctx != null && udpEnabled) {
             val displayName = deviceManager.localDisplayNameInternal()
-            val battery = notifyrelay.core.util.BatteryUtils.getBatteryLevel(deviceManager.contextInternal)
+            // 问题 4 修复：同 syncHeartbeatMode，广播电量需带符号。
+            val battery = getSignedBatteryLevel()
             NativeCore.periodicBroadcast(ctx, 1, deviceManager.uuid, displayName, battery, "android")
         }
 

--- a/app/src/main/java/com/xzyht/notifyrelay/ui/activity/MainActivity.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/ui/activity/MainActivity.kt
@@ -84,6 +84,7 @@ import com.xzyht.notifyrelay.ui.screen.ScrcpyVirtualButtonOrderScreen
 import com.xzyht.notifyrelay.ui.screen.SettingsScreen
 import io.github.miuzarte.scrcpyforandroid.pages.ScrcpyRootScreen
 import io.github.miuzarte.scrcpyforandroid.pages.ScrcpyScreenHost
+import io.github.miuzarte.scrcpyforandroid.pages.ScrcpyUiViewModel
 import io.github.miuzarte.scrcpyforandroid.pages.ShortcutLaunchActivity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -95,6 +96,8 @@ import notifyrelay.base.util.ThemeSettingsManager
 import notifyrelay.base.util.ToastUtils
 import notifyrelay.core.util.ServiceManager
 import notifyrelay.data.config.DeviceInfoManager
+import notifyrelay.data.config.ScrcpyPreferenceKeys
+import notifyrelay.data.StorageManager
 import top.yukonga.miuix.kmp.basic.Button
 import top.yukonga.miuix.kmp.basic.Icon
 import top.yukonga.miuix.kmp.basic.NavigationBar
@@ -341,6 +344,20 @@ class MainActivity : FragmentActivity() {
                                                 uri,
                                                 Intent.FLAG_GRANT_READ_URI_PERMISSION
                                             )
+                                            // 问题 5 修复：原回调仅 takePersistableUriPermission，未写入 CUSTOM_SERVER_URI；
+                                            // 且 ScrcpyUiViewModel 是单例，只写 StorageManager 不会让 UI/连接生效。
+                                            // 双写：1) StorageManager 持久化；2) viewModel setter 更新单例状态（内部也会持久化到 mainSettings）。
+                                            val uriString = uri.toString()
+                                            StorageManager.putString(
+                                                context,
+                                                ScrcpyPreferenceKeys.CUSTOM_SERVER_URI,
+                                                uriString,
+                                                StorageManager.PrefsType.SCRCPY
+                                            )
+                                            val app = context.applicationContext as android.app.Application
+                                            ScrcpyUiViewModel.getInstance(app).customServerUri = uriString
+                                        }.onFailure { e ->
+                                            Logger.e("MainActivity", "scrcpy server URI 保存失败: uri=$uri", e)
                                         }
                                     }
                                     ScrollableTopAppBarPage(

--- a/app/src/main/java/com/xzyht/notifyrelay/ui/pages/UILocalFilter.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/ui/pages/UILocalFilter.kt
@@ -7,15 +7,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.xzyht.notifyrelay.feature.notification.backend.BackendLocalFilter
+import kotlinx.coroutines.launch
 import top.yukonga.miuix.kmp.basic.Card
 import top.yukonga.miuix.kmp.basic.CardDefaults
 import top.yukonga.miuix.kmp.basic.Text
@@ -32,6 +35,7 @@ fun UILocalFilter(
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     // 状态管理
     var filterSelf by remember { mutableStateOf(BackendLocalFilter.filterSelf) }
     var filterOngoing by remember { mutableStateOf(BackendLocalFilter.filterOngoing) }
@@ -39,11 +43,19 @@ fun UILocalFilter(
     var filterImportanceNone by remember { mutableStateOf(BackendLocalFilter.filterImportanceNone) }
 
     // 过滤条目相关状态（统一管理关键词+包名）
-    var allEntries by remember { mutableStateOf(BackendLocalFilter.getFilterEntries(context).toList()) }
-    var enabledEntries by remember { mutableStateOf(BackendLocalFilter.getEnabledFilterEntries(context)) }
+    // 组合期不再同步查库，先给空集合，由 LaunchedEffect 异步加载
+    var allEntries by remember { mutableStateOf<List<BackendLocalFilter.FilterEntry>>(emptyList()) }
+    var enabledEntries by remember { mutableStateOf<Set<BackendLocalFilter.FilterEntry>>(emptySet()) }
 
     val builtinKeywords = remember { BackendLocalFilter.getBuiltinKeywords() }
     val builtinPackages = remember { BackendLocalFilter.getDefaultPackageFilters() }
+
+    // 异步加载过滤条目
+    LaunchedEffect(Unit) {
+        allEntries = BackendLocalFilter.getFilterEntries(context).toList()
+        enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+    }
+
     val builtinDefaultEntries = remember(allEntries, builtinKeywords, builtinPackages) {
         allEntries.filter { entry -> (entry.keyword.isNotBlank() && builtinKeywords.contains(entry.keyword)) || (entry.packageName.isNotBlank() && builtinPackages.contains(entry.packageName)) }
     }
@@ -142,18 +154,24 @@ fun UILocalFilter(
                 manualEntries = customEntries.map { FilterEntryItem(it.keyword, it.packageName) },
                 entryEnabled = { enabledEntries.contains(BackendLocalFilter.FilterEntry(it.keyword, it.packageName)) },
                 onEntryEnabledChange = { item, enabled ->
-                    BackendLocalFilter.setFilterEntryEnabled(context, BackendLocalFilter.FilterEntry(item.keyword, item.packageName), enabled)
-                    enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    scope.launch {
+                        BackendLocalFilter.setFilterEntryEnabled(context, BackendLocalFilter.FilterEntry(item.keyword, item.packageName), enabled)
+                        enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    }
                 },
                 onAddEntry = { keyword, pkg ->
-                    BackendLocalFilter.addFilterEntry(context, keyword, pkg)
-                    allEntries = BackendLocalFilter.getFilterEntries(context).toList()
-                    enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    scope.launch {
+                        BackendLocalFilter.addFilterEntry(context, keyword, pkg)
+                        allEntries = BackendLocalFilter.getFilterEntries(context).toList()
+                        enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    }
                 },
                 onRemoveEntry = { item ->
-                    BackendLocalFilter.removeFilterEntry(context, item.keyword, item.packageName)
-                    allEntries = BackendLocalFilter.getFilterEntries(context).toList()
-                    enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    scope.launch {
+                        BackendLocalFilter.removeFilterEntry(context, item.keyword, item.packageName)
+                        allEntries = BackendLocalFilter.getFilterEntries(context).toList()
+                        enabledEntries = BackendLocalFilter.getEnabledFilterEntries(context)
+                    }
                 }
             )
         }

--- a/app/src/main/java/com/xzyht/notifyrelay/ui/pages/UIRemoteFilter.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/ui/pages/UIRemoteFilter.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.xzyht.notifyrelay.feature.notification.backend.RemoteFilterConfig
 import com.xzyht.notifyrelay.servers.appslist.AppRepository
 import com.xzyht.notifyrelay.ui.dialog.AppPickerDialog
+import kotlinx.coroutines.launch
 import top.yukonga.miuix.kmp.basic.Button
 import top.yukonga.miuix.kmp.basic.HorizontalDivider
 import top.yukonga.miuix.kmp.basic.Text
@@ -43,6 +45,7 @@ import top.yukonga.miuix.kmp.theme.MiuixTheme
 @Composable
 fun UIRemoteFilter() {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
 
     // 前端状态 - 先使用默认值，然后在配置加载完成后更新
     var filterMode by remember { mutableStateOf("none") }
@@ -58,14 +61,27 @@ fun UIRemoteFilter() {
     var filterItems by remember {
         mutableStateOf(RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) })
     }
-    
+
+    // B1 修复：enabledKeys 作为 Compose 状态，键为 "$packageName|$keyword"。
+    // 直接读 RemoteFilterConfig.isActiveEntryEnabled（非 Compose 状态）+ data class 结构相等
+    // 不会触发重组，改用独立状态集合并在每次变更后刷新。
+    var enabledKeys by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    // 刷新 enabledKeys 的统一入口：从 RemoteFilterConfig 当前名单派生启用集合
+    fun refreshEnabledKeys() {
+        val active = RemoteFilterConfig.getActiveFilterList()
+        enabledKeys = active.filter { (pkg, kw) ->
+            RemoteFilterConfig.isActiveEntryEnabled(pkg, kw ?: "")
+        }.map { (pkg, kw) -> "$pkg|${kw ?: ""}" }.toSet()
+    }
+
     // 在LaunchedEffect中异步加载RemoteFilterConfig，避免阻塞UI
     LaunchedEffect(Unit) {
         if (!RemoteFilterConfig.isLoaded) {
             RemoteFilterConfig.load(context)
             RemoteFilterConfig.isLoaded = true
         }
-        
+
         // 配置加载完成后更新前端状态
         filterMode = RemoteFilterConfig.filterMode
         enableDedup = RemoteFilterConfig.enableDeduplication
@@ -75,6 +91,7 @@ fun UIRemoteFilter() {
         allGroupEnabled = (RemoteFilterConfig.defaultGroupEnabled + RemoteFilterConfig.customGroupEnabled).toMutableList()
         filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
         enableLockScreenOnly = RemoteFilterConfig.enableLockScreenOnly
+        refreshEnabledKeys()
     }
 
     var showAppPickerForGroup by remember { mutableStateOf<Pair<Boolean, Int>>(false to -1) }
@@ -97,12 +114,12 @@ fun UIRemoteFilter() {
         summary = "智能去重，避免重复通知",
         onCheckedChange = {
             RemoteFilterConfig.enableDeduplication = it
-            RemoteFilterConfig.save(context)
+            scope.launch { RemoteFilterConfig.save(context) }
             enableDedup = it
         }
     )
     HorizontalDivider(modifier = Modifier.padding(horizontal = 32.dp))
-    
+
     // 锁屏通知过滤
     SwitchPreference(
         title = "仅复刻锁屏通知到通知栏",
@@ -110,7 +127,7 @@ fun UIRemoteFilter() {
         summary = "仅复刻锁屏状态的通知到通知栏",
         onCheckedChange = {
             RemoteFilterConfig.enableLockScreenOnly = it
-            RemoteFilterConfig.save(context)
+            scope.launch { RemoteFilterConfig.save(context) }
             enableLockScreenOnly = it
         }
     )
@@ -130,9 +147,16 @@ fun UIRemoteFilter() {
             val (value, _) = modes[safeIdx]
             RemoteFilterConfig.filterMode = value
             RemoteFilterConfig.enablePeerMode = (value == "peer")
-            RemoteFilterConfig.save(context)
+            scope.launch {
+                RemoteFilterConfig.save(context)
+                // 保存完成后再刷新派生状态（save 内部会重写名单表，避免读到中间态）
+                filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                refreshEnabledKeys()
+            }
             filterMode = value
+            // 立即同步 UI 状态（不等 save 完成，保证响应感）
             filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+            refreshEnabledKeys()
         }
     )
 
@@ -140,18 +164,27 @@ fun UIRemoteFilter() {
         // 黑白名单配置区（添加 + 手动黑名单抽屉 + 条目禁用），复用本机过滤的公共组件
         FilterListSection(
             manualEntries = filterItems,
-            entryEnabled = { item -> RemoteFilterConfig.isActiveEntryEnabled(item.packageName, item.keyword) },
+            entryEnabled = { item -> enabledKeys.contains("${item.packageName}|${item.keyword}") },
             onEntryEnabledChange = { item, enabled ->
-                RemoteFilterConfig.setFilterEntryEnabled(context, item.packageName, item.keyword, enabled)
-                filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                scope.launch {
+                    RemoteFilterConfig.setFilterEntryEnabled(context, item.packageName, item.keyword, enabled)
+                    filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                    refreshEnabledKeys()
+                }
             },
             onAddEntry = { keyword, pkg ->
-                RemoteFilterConfig.addFilterEntry(context, pkg, keyword)
-                filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                scope.launch {
+                    RemoteFilterConfig.addFilterEntry(context, pkg, keyword)
+                    filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                    refreshEnabledKeys()
+                }
             },
             onRemoveEntry = { item ->
-                RemoteFilterConfig.removeFilterEntry(context, item.packageName, item.keyword)
-                filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                scope.launch {
+                    RemoteFilterConfig.removeFilterEntry(context, item.packageName, item.keyword)
+                    filterItems = RemoteFilterConfig.getActiveFilterList().map { FilterEntryItem(it.second ?: "", it.first) }
+                    refreshEnabledKeys()
+                }
             }
         )
     }
@@ -162,7 +195,7 @@ fun UIRemoteFilter() {
         summary = "启用包名等价映射功能",
         onCheckedChange = {
             RemoteFilterConfig.enablePackageGroupMapping = it
-            RemoteFilterConfig.save(context)
+            scope.launch { RemoteFilterConfig.save(context) }
             enablePackageGroupMapping = it
         },
         modifier = Modifier.padding(top = 16.dp)
@@ -173,7 +206,7 @@ fun UIRemoteFilter() {
     Column(modifier = Modifier.fillMaxWidth()) {
         allGroups.forEachIndexed { idx, group ->
             val groupName = if (idx < RemoteFilterConfig.defaultPackageGroups.size) "默认组${idx+1}" else "自定义组${idx+1-RemoteFilterConfig.defaultPackageGroups.size}"
-            
+
             Column(modifier = Modifier.fillMaxWidth()) {
                 // 将CheckboxPreference和操作按钮放在同一行
                 Row(
@@ -192,12 +225,12 @@ fun UIRemoteFilter() {
                             val defaultSize = RemoteFilterConfig.defaultPackageGroups.size
                             RemoteFilterConfig.defaultGroupEnabled = newEnabled.take(defaultSize).toMutableList()
                             RemoteFilterConfig.customGroupEnabled = newEnabled.drop(defaultSize).toMutableList()
-                            RemoteFilterConfig.save(context)
+                            scope.launch { RemoteFilterConfig.save(context) }
                         },
                         enabled = enablePackageGroupMapping,
                         modifier = Modifier.weight(1f)
                     )
-                    
+
                     // 右侧操作按钮组
                     Row(
                         modifier = Modifier.padding(start = 4.dp, end = 4.dp),
@@ -222,7 +255,7 @@ fun UIRemoteFilter() {
                                     val defaultSize = RemoteFilterConfig.defaultPackageGroups.size
                                     RemoteFilterConfig.customPackageGroups = newGroups.drop(defaultSize).map { it.toMutableList() }.toMutableList()
                                     RemoteFilterConfig.customGroupEnabled = newEnabled.drop(defaultSize).toMutableList()
-                                    RemoteFilterConfig.save(context)
+                                    scope.launch { RemoteFilterConfig.save(context) }
                                 },
                                 modifier = Modifier.defaultMinSize(minWidth = 28.dp, minHeight = 28.dp).padding(start = 2.dp),
                                 enabled = enablePackageGroupMapping
@@ -232,7 +265,7 @@ fun UIRemoteFilter() {
                         }
                     }
                 }
-                
+
                 // 包名自动换行显示
                 FlowRow(
                     modifier = Modifier.fillMaxWidth().padding(start = 60.dp, top = 0.dp, bottom = 2.dp),
@@ -242,19 +275,19 @@ fun UIRemoteFilter() {
                     // 监听AppRepository的状态，确保数据已加载
                     val installedPkgs by remember { AppRepository.apps }.collectAsState()
                     val installedPkgSet = installedPkgs.map { it.packageName }.toSet()
-                    
+
                     // 确保应用列表已加载
                     LaunchedEffect(Unit) {
                         if (!AppRepository.isDataLoaded()) {
                             AppRepository.loadApps(context)
                         }
                     }
-                    
+
                     group.forEach { pkg ->
                         val isInstalled = installedPkgSet.contains(pkg)
                         // 使用mutableStateOf保存图标状态，这样更新时会触发UI重新渲染
                         var iconBitmap by remember { mutableStateOf<Bitmap?>(null) }
-                        
+
                         // 异步加载缺失的图标，并在加载完成后更新状态
                         LaunchedEffect(pkg) {
                             if (iconBitmap == null) {
@@ -264,14 +297,14 @@ fun UIRemoteFilter() {
                                 iconBitmap = loadedIcon
                             }
                         }
-                        
+
                         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(end = 6.dp)) {
                             iconBitmap?.let { Image(bitmap = it.asImageBitmap(), contentDescription = null, modifier = Modifier.size(16.dp)) }
                             Text(pkg, style = textStyles.body2, color = if (isInstalled) colorScheme.primary else colorScheme.onSurface, modifier = Modifier.padding(start = 2.dp))
                         }
                     }
                 }
-                
+
                 // 在每组之间添加分割线，最后一组除外
                 if (idx < allGroups.size - 1) {
                     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -280,7 +313,7 @@ fun UIRemoteFilter() {
         }
     }
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
-    
+
     // 添加新组按钮
     ArrowPreference(
         title = "添加新组",
@@ -293,12 +326,12 @@ fun UIRemoteFilter() {
             val defaultSize = RemoteFilterConfig.defaultPackageGroups.size
             RemoteFilterConfig.customPackageGroups = newGroups.drop(defaultSize).map { it.toMutableList() }.toMutableList()
             RemoteFilterConfig.customGroupEnabled = newEnabled.drop(defaultSize).toMutableList()
-            RemoteFilterConfig.save(context)
+            scope.launch { RemoteFilterConfig.save(context) }
         },
         modifier = Modifier.padding(vertical = 2.dp),
         enabled = enablePackageGroupMapping
     )
-    
+
     // 在添加新组按钮下方添加分割线
     HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
@@ -318,11 +351,11 @@ fun UIRemoteFilter() {
                 // 更新后端状态
                 val defaultSize = RemoteFilterConfig.defaultPackageGroups.size
                 RemoteFilterConfig.customPackageGroups = newGroups.drop(defaultSize).map { it.toMutableList() }.toMutableList()
-                RemoteFilterConfig.save(context)
+                scope.launch { RemoteFilterConfig.save(context) }
                 showAppPickerForGroup = false to -1
             },
             title = "选择应用"
         )}
     }
 }
-    
+

--- a/app/src/main/java/com/xzyht/notifyrelay/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/com/xzyht/notifyrelay/ui/screen/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,6 +35,14 @@ fun SettingsScreen() {
     val colorScheme = MiuixTheme.colorScheme
     var isDeveloperModeEnabled by remember {
         mutableStateOf(StorageManager.getBoolean(context, "developer_mode_enabled", false))
+    }
+
+    // 问题 7 修复：开发者模式入口在"关于"子页激活后返回时不会刷新。
+    // ON_RESUME 方案在本导航架构（Navigator 为 rememberSaveable + 栈内重组，路由 push/pop
+    // 不改变 Activity lifecycle）下无效。改用 LaunchedEffect 监听 backStack.size：
+    // 从"关于"返回时栈大小变小，触发重新读取 developer_mode_enabled。
+    LaunchedEffect(navigator.backStack.size) {
+        isDeveloperModeEnabled = StorageManager.getBoolean(context, "developer_mode_enabled", false)
     }
 
     Column(

--- a/data/src/main/java/notifyrelay/data/database/AppDatabase.kt
+++ b/data/src/main/java/notifyrelay/data/database/AppDatabase.kt
@@ -361,8 +361,10 @@ abstract class AppDatabase : RoomDatabase() {
                     migratePackageGroups(database)
                     migrateMirrorFilterDefaults(database)
                 } catch (e: Exception) {
-                    Logger.e("AppDatabase", "MIGRATION_7_8 名单数据迁移失败，旧数据保留在 app_config", e)
-                    return
+                    // 抛出异常以让 Room 回滚整个迁移事务，避免版本被标记为 8 但表为空导致数据静默丢失；
+                    // 下次启动会重新尝试迁移（旧数据仍保留在 app_config 中）
+                    Logger.e("AppDatabase", "MIGRATION_7_8 名单数据迁移失败，将回滚迁移事务", e)
+                    throw e
                 }
 
                 // 3. 清理已迁移的旧 key
@@ -395,6 +397,20 @@ abstract class AppDatabase : RoomDatabase() {
                 @Suppress("UNCHECKED_CAST")
                 (Gson().fromJson(json, type) as? Set<String>) ?: emptySet()
             }.getOrDefault(emptySet())
+        }
+
+        /**
+         * 解析 JSON 数组字符串为有序 List。
+         * 与 parseJsonSet 不同：保留原始顺序，专用于自定义包名组（依赖顺序保证命名一致性）。
+         * Set 反序列化时顺序不可靠，会导致迁移后命名与 savePackageGroups 不一致。
+         */
+        private fun parseJsonList(json: String?): List<String> {
+            if (json.isNullOrBlank()) return emptyList()
+            return runCatching {
+                val type = object : TypeToken<List<String>>() {}.type
+                @Suppress("UNCHECKED_CAST")
+                (Gson().fromJson(json, type) as? List<String>) ?: emptyList()
+            }.getOrDefault(emptyList())
         }
 
         /** 黑白名单条目 "pkg|keyword" 或 "pkg" 解析为 (包名, 关键词) */
@@ -475,8 +491,8 @@ abstract class AppDatabase : RoomDatabase() {
                     )
                 }
             }
-            // 自定义组
-            val customRaw = parseJsonSet(readConfigValue(db, "filter_package_groups"))
+            // 自定义组（使用 parseJsonList 保留 JSON 数组顺序，避免 Set 反序列化导致命名错位）
+            val customRaw = parseJsonList(readConfigValue(db, "filter_package_groups"))
             val customEnabled = (readConfigValue(db, "filter_custom_group_enabled") ?: "")
                 .split(",").map { it == "1" }
             customRaw.forEachIndexed { idx, groupStr ->
@@ -485,7 +501,7 @@ abstract class AppDatabase : RoomDatabase() {
                 val enabled = customEnabled.getOrNull(idx) ?: true
                 db.execSQL(
                     "INSERT INTO package_groups (groupName, enabled, isDefault) VALUES (?, ?, 0)",
-                    arrayOf<Any?>("自定义组${idx + 1 - FilterConfigDefaults.defaultPackageGroups.size}", if (enabled) 1 else 0)
+                    arrayOf<Any?>("自定义组${idx + 1}", if (enabled) 1 else 0)
                 )
                 val groupId = lastInsertRowId(db)
                 pkgs.forEach { pkg ->

--- a/data/src/main/java/notifyrelay/data/database/dao/FilterListDao.kt
+++ b/data/src/main/java/notifyrelay/data/database/dao/FilterListDao.kt
@@ -73,6 +73,27 @@ interface FilterListDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPackageGroupItems(items: List<PackageGroupItemEntity>)
 
+    /** 全量替换黑名单（clear + insert 原子执行） */
+    @Transaction
+    suspend fun replaceBlackList(entries: List<BlackListEntryEntity>) {
+        clearBlackList()
+        if (entries.isNotEmpty()) insertBlackList(entries)
+    }
+
+    /** 全量替换白名单（clear + insert 原子执行） */
+    @Transaction
+    suspend fun replaceWhiteList(entries: List<WhiteListEntryEntity>) {
+        clearWhiteList()
+        if (entries.isNotEmpty()) insertWhiteList(entries)
+    }
+
+    /** 全量替换本地过滤条目（clear + insert 原子执行） */
+    @Transaction
+    suspend fun replaceFilterEntries(entries: List<FilterEntryEntity>) {
+        clearFilterEntries()
+        if (entries.isNotEmpty()) insertFilterEntries(entries)
+    }
+
     /** 全量替换包名等价组（组 + 组内包名，itemPackages 与 groups 一一对应） */
     @Transaction
     suspend fun replacePackageGroups(groups: List<PackageGroupEntity>, itemPackages: List<List<String>>) {

--- a/data/src/main/java/notifyrelay/data/database/repository/DatabaseRepository.kt
+++ b/data/src/main/java/notifyrelay/data/database/repository/DatabaseRepository.kt
@@ -501,8 +501,7 @@ class DatabaseRepository(private val database: AppDatabase) {
     }
 
     suspend fun replaceBlackList(entries: List<BlackListEntryEntity>) {
-        filterListDao.clearBlackList()
-        if (entries.isNotEmpty()) filterListDao.insertBlackList(entries)
+        filterListDao.replaceBlackList(entries)
     }
 
     suspend fun getWhiteList(): List<WhiteListEntryEntity> {
@@ -510,8 +509,7 @@ class DatabaseRepository(private val database: AppDatabase) {
     }
 
     suspend fun replaceWhiteList(entries: List<WhiteListEntryEntity>) {
-        filterListDao.clearWhiteList()
-        if (entries.isNotEmpty()) filterListDao.insertWhiteList(entries)
+        filterListDao.replaceWhiteList(entries)
     }
 
     suspend fun getLocalFilterEntries(): List<FilterEntryEntity> {
@@ -519,8 +517,7 @@ class DatabaseRepository(private val database: AppDatabase) {
     }
 
     suspend fun replaceLocalFilterEntries(entries: List<FilterEntryEntity>) {
-        filterListDao.clearFilterEntries()
-        if (entries.isNotEmpty()) filterListDao.insertFilterEntries(entries)
+        filterListDao.replaceFilterEntries(entries)
     }
 
     suspend fun getPackageGroups(): List<PackageGroupEntity> {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,100 @@
+# PR #48 CodeRabbit 评审 → 修复计划
+
+## 验证结论汇总
+
+| # | 问题 | 验证结果 | 处置 |
+|---|------|---------|------|
+| 1 | registerReceiver flags 兼容性 | **部分真实**：minSdk=31，但三参数重载 API 26+ 已存在，**不会抛 NoSuchMethodError**；`RECEIVER_NOT_EXPORTED`(值4) 语义仅 API 33+ 生效，API 31/32 上等效 exported。注册的全是受保护系统广播（SCREEN_OFF/SCREEN_ON/USER_PRESENT/BATTERY_CHANGED），无实际崩溃/安全风险 | 做防御性修复（API 分支） |
+| 2 | runBlocking 桥接 + 重复查询 | **真实**（getEnabledFilterEntries 每条通知查库 2 次；多个同步调用方） | ✅ 用户已确认：**全面 suspend 化** |
+| 3 | 内置条目开关无效 | **真实**：`getEnabledFilterEntries` 强制加回内置条目（BackendLocalFilter.kt:78-80），注释"恒启用"但 UI 提供开关 | ✅ 用户已确认：**允许用户禁用内置条目** |
+| 4 | 电量不带符号 | **真实**：`syncHeartbeatMode` 与 `startDiscovery` 均传正值，远端会误判全部设备为"充电中"（Rust 侧 battery>0=充电；BatteryReceiver 路径才是带符号的） | 修复两处 |
+| 5 | scrcpy server URI 未保存 | **真实**：回调仅 takePersistableUriPermission，未写入 `CUSTOM_SERVER_URI`；且 `ScrcpyUiViewModel` 是**单例**（getInstance），只写 StorageManager 不会让 UI/连接生效 | 修复（app 模块内即可，通过 viewModel setter 双写） |
+| 6 | 远程过滤开关 UI 不刷新 | **真实**：`entryEnabled` 读非 Compose 状态；`mutableStateOf` 对 data class 结构相等不触发重组 | 修复（enabledKeys 状态） |
+| 7 | 开发者模式入口不刷新 | **真实**；但 CodeRabbit 建议的 ON_RESUME 方案**在本导航架构下无效**（Navigator 是 `rememberSaveable`+栈内重组，路由 push/pop 不改变 Activity lifecycle） | 修复（改用 `LaunchedEffect(backStack.size)` 或全局状态） |
+| 8 | 迁移失败后不再重试 | **真实**：catch→return 导致 Room 提交版本 8，数据静默丢失 | 修复（抛出异常回滚） |
+| 9 | 自定义组命名负数 + 启用错配 | **真实**：`"自定义组${idx+1-3}"` 对 idx=0 生成"自定义组-2"（与 savePackageGroups 的"自定义组1"不一致）；Set 解析顺序不可靠 | 修复（parseJsonList + 命名修正） |
+| 10 | 替换操作无事务 | **真实**：clear+insert 非原子（FilterListDao 已有 replacePackageGroups 的 @Transaction 先例） | 修复（照搬模板） |
+| 11 | scrcpy 子模块提交不存在 | ~~疑似误报/已过时~~ | ✅ **已在 PR CI 时修复，无需处理** |
+| 12 | Docstring 覆盖率 26.92% | 与项目现状不符（全库无 docstring 强制约定） | 跳过 |
+| 13 | PR 标题"Build"过于笼统 | 属实 | 合并时改标题（提示项） |
+
+---
+
+## 修复任务清单
+
+### A. 通知过滤后端 suspend 化（问题 2，含问题 3 决策）
+
+**A1. `app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendLocalFilter.kt`**
+- `getFilterEntries`、`getEnabledFilterEntries` 改为 `suspend`：合并为**一次查询**，复用行集；删除 `getFilterEntries` 内的二次查询与 `getEnabledFilterEntries` 内的重复查询（L74-77）
+- **删除 L78-80 内置条目强制加入逻辑**（问题 3：允许用户禁用）
+- `setFilterEntryEnabled`、`addFilterEntry`、`removeFilterEntry` 改为 `suspend`
+- `shouldForward` 改为 `suspend`；其内部热路径只调用 suspend 过滤方法（消除每次通知 2 次 runBlocking 查询）
+- 同步契约保留：`NotifyRelayNotificationListenerService.kt:457` 等非协程回调处，用 `CoroutineScope(Dispatchers.IO).launch` + 结果回传同步化，或保留一个内部 `runBlocking` 薄包装（实现时按调用上下文选择，保持服务回调语义不变）
+
+**A2. `app/src/main/java/com/xzyht/notifyrelay/feature/notification/backend/BackendRemoteFilter.kt`（RemoteFilterConfig）**
+- `load`、`loadFilterLists`、`loadPackageGroups`、`save`、`saveFilterLists`、`savePackageGroups` 改为 `suspend`，`runBlocking` 替换为 `withContext(Dispatchers.IO)`（save 内的 `syncToRust` 调用保留）
+- `filterRemoteNotification`（L75，同步契约，被消息处理链调用）：内部由 runBlocking 包 suspend load 改为——若调用链可挂起则挂起，否则保留最小 runBlocking 兜底并注释原因
+
+**A3. 调用方（app 模块）**
+- `UILocalFilter.kt`：L42-43 的组合期同步初始化 → `LaunchedEffect` 异步加载（加 loading 态）；L144-157 回调 → `rememberCoroutineScope().launch`
+- `UIRemoteFilter.kt`：L65 已有 LaunchedEffect 可挂起；L100-321 各处 `save` → 协程回调
+- `NotificationHistoryViewModel.kt:66` → `viewModelScope.launch`
+- `DeviceForwardScreen.kt:47` → 所在 Effect/作用域适配
+- `NotifyRelayNotificationListenerService.kt:457` → 见 A1 同步化方案
+
+### B. UI 状态类修复（问题 6、7）
+
+**B1. `app/src/main/java/com/xzyht/notifyrelay/ui/pages/UIRemoteFilter.kt`（问题 6）**
+- 新增 `enabledKeys` 状态（SnapshotStateSet 或 `mutableStateOf<Set<String>>`），键为 `"$packageName|$keyword"`
+- `entryEnabled` 改读 `enabledKeys`；在 LaunchedEffect、onEntryEnabledChange、onAddEntry、onRemoveEntry、模式切换后同步刷新（与 `filterItems` 刷新一致）
+- `setFilterEntryEnabled` 持久化逻辑保持不变
+
+**B2. `app/src/main/java/com/xzyht/notifyrelay/ui/screen/SettingsScreen.kt`（问题 7）**
+- 放弃 ON_RESUME 方案（已证无效）
+- 改为 `LaunchedEffect(navigator.backStack.size)`：栈变化（从"关于"返回）时重新读取 `StorageManager.getBoolean(context, "developer_mode_enabled", false)` 并更新 `isDeveloperModeEnabled`
+- 备选（实现时取更简洁者）：与 `DeveloperModeActivity.DEBUG_UI_ENABLED` 同模式，提升为全局 `MutableState`，由 `UIAbout` 激活时同步更新——但需新增状态容器并改 UIAbout
+
+### C. 收发与同步修复（问题 1、4、5）
+
+**C1. `app/src/main/java/com/xzyht/notifyrelay/feature/device/service/DeviceConnectionManager.kt`（问题 1）**
+- L615 与 L643-649 两处：`if (Build.VERSION.SDK_INT >= 33) registerReceiver(r, f, RECEIVER_NOT_EXPORTED) else registerReceiver(r, f)`
+- 保留现有 try/catch
+
+**C2. `app/src/main/java/com/xzyht/notifyrelay/sync/ConnectionDiscoveryManager.kt`（问题 4）**
+- `syncHeartbeatMode` 与 `startDiscovery` 两处：按 BatteryReceiver 约定读取带符号电量（`isCharging ? level : -level`）
+- 建议提取私有辅助如 `getSignedBatteryLevel()`，两处共用
+
+**C3. `app/src/main/java/com/xzyht/notifyrelay/ui/activity/MainActivity.kt`（问题 5）**
+- serverPicker 回调：`takePersistableUriPermission` 成功后将 `uri.toString()` 同时写入：
+  1. `StorageManager`（`PrefsType.SCRCPY`、`ScrcpyPreferenceKeys.CUSTOM_SERVER_URI`）
+  2. `ScrcpyUiViewModel.getInstance(app).customServerUri = uri.toString()`（setter 内部自动持久化+更新单例状态，使设置页展示与实际连接都生效）
+- `runCatching` 失败改为 `Logger.e` 记录，不再静默
+- 保留 `uri == null` 直接返回
+
+### D. 数据库层修复（问题 8、9、10）
+
+**D1. `data/src/main/java/notifyrelay/data/database/AppDatabase.kt` 迁移（问题 8）**
+- MIGRATION_7_8 的 catch 中 `return`（L365）改为 `throw e`，使 Room 回滚事务、下次启动重试迁移（保留 Logger.e 诊断）
+
+**D2. `AppDatabase.kt` migratePackageGroups（问题 9）**
+- 新增 `parseJsonList`（`TypeToken<List<String>>`）保留 JSON 数组顺序
+- L479 改用它；L488 命名改为 `"自定义组${idx + 1}"`（与 `savePackageGroups` 一致），移除默认组数量偏移
+- `parseJsonSet` 保留给其他迁移（黑白名单用 contains 匹配，顺序无关）
+
+**D3. `FilterListDao.kt` + `DatabaseRepository.kt`（问题 10）**
+- DAO 新增 `@Transaction` 默认方法：`replaceBlackList`、`replaceWhiteList`、`replaceFilterEntries`（clear + insert，照搬 L77-87 `replacePackageGroups` 模板）
+- Repository L503-506 / L512-515 / L521-524 三个方法改为委托给对应 DAO 事务方法
+
+### E. 验证与收尾
+
+**E1. 构建验证**：按 AGENTS.md 规范首次构建禁止筛选输出；验证 `:app` 与 `:data` 编译通过、单元测试（若有）通过
+
+**E2. PR 标题**：合并时改为描述性标题（如"过滤配置迁移数据库 + 设置子页面 + TCP 备用心跳"），Docstring 检查跳过
+
+---
+
+## 明确不做
+
+- 问题 11（scrcpy 子模块）：已在 PR CI 时修复，不涉及代码修改
+- Docstring 覆盖率补全（不符合本项目约定）
+- 迁移逻辑之外的表结构改动


### PR DESCRIPTION
Changes:

将本地/远程过滤配置的关键读写路径从同步阻塞改为以 suspend 为主，并在同步入口保留最小 runBlocking 兜底。
修复远程过滤列表启用态的 Compose 状态驱动刷新问题；修复设置页从子页返回后开发者模式入口不刷新的问题。
修复 Room 迁移失败“静默丢数据”、自定义组命名错位，以及名单 replace 操作缺少事务的问题；同时修复发现/心跳电量符号语义与 scrcpy server URI 保存逻辑。